### PR TITLE
Adding improvement for SMB test suite.

### DIFF
--- a/keywords/api/post.py
+++ b/keywords/api/post.py
@@ -138,8 +138,7 @@ class API_POST:
         :param service: is the service nome.
         :return: True if the service is running, otherwise False.
         """
-        print(POST('service/started/', service))
-        return bool(POST('service/started/', service).text)
+        return POST('/service/started/', service).json()
 
     @classmethod
     def restart_replication_service(cls, service: str) -> Response:

--- a/keywords/webui/common.py
+++ b/keywords/webui/common.py
@@ -143,7 +143,7 @@ class Common:
         Example:
             - Common.cancel_confirm_dialog()
         """
-        assert cls.is_visible(xpaths.common_xpaths.button_field('dialog-cancel'))
+        assert WebUI.wait_until_clickable(xpaths.common_xpaths.button_field('dialog-cancel'))
         WebUI.xpath(xpaths.common_xpaths.button_field('dialog-cancel')).click()
         WebUI.delay(1)
 

--- a/keywords/webui/common.py
+++ b/keywords/webui/common.py
@@ -232,7 +232,7 @@ class Common:
         """
         WebUI.wait_until_clickable(xpaths.common_xpaths.button_field('save'), shared_config['MEDIUM_WAIT']).click()
         WebUI.delay(2)
-        WebUI.wait_until_not_visible('(//ix-icon[@name="cancel"])[1]')
+
 
     @classmethod
     def close_right_panel(cls) -> None:

--- a/keywords/webui/smb.py
+++ b/keywords/webui/smb.py
@@ -43,7 +43,7 @@ class SMB:
         This method clicks the add share button on the Shares page
         """
         WebUI.xpath(xpaths.common_xpaths.button_field('smb-share-add')).click()
-        assert COM.is_visible(xpaths.common_xpaths.any_header('Add SMB', 3))
+        assert COM.assert_right_panel_header('Add SMB')
 
     @classmethod
     def click_edit_share_filesystem_acl(cls, name: str) -> None:
@@ -83,24 +83,21 @@ class SMB:
         """
         This method sets the afp checkbox.
         """
-        assert COM.is_visible(xpaths.common_xpaths.checkbox_field('afp'))
-        WebUI.xpath(xpaths.common_xpaths.checkbox_field('afp')).click()
+        COM.set_checkbox('afp')
 
     @classmethod
     def set_audit_logging_enable(cls) -> None:
         """
         This method sets the audit logging enable checkbox.
         """
-        assert COM.is_visible(xpaths.common_xpaths.checkbox_field('enable'))
-        WebUI.xpath(xpaths.common_xpaths.checkbox_field('enable')).click()
+        COM.set_checkbox('enable')
 
     @classmethod
     def set_guest_ok(cls) -> None:
         """
         This method sets the guest ok checkbox.
         """
-        assert COM.is_visible(xpaths.common_xpaths.checkbox_field('guestok'))
-        WebUI.xpath(xpaths.common_xpaths.checkbox_field('guestok')).click()
+        COM.set_checkbox('guestok')
 
     @classmethod
     def set_ignore_list(cls, name: str) -> None:
@@ -119,7 +116,7 @@ class SMB:
         """
         This method sets the purpose for the share on the Edit Share right panel
         """
-        COM.is_visible(xpaths.common_xpaths.select_field('purpose'))
+        WebUI.wait_until_visible(xpaths.common_xpaths.select_field('purpose'))
         WebUI.xpath(xpaths.common_xpaths.select_field('purpose')).click()
         purpose = purpose.replace(' ', '-').lower()
         WebUI.xpath(xpaths.common_xpaths.option_field('purpose-' + purpose)).click()

--- a/test_cases/webui/shares/smb/conftest.py
+++ b/test_cases/webui/shares/smb/conftest.py
@@ -3,4 +3,9 @@ from keywords.webui.common import Common
 
 
 def pytest_sessionstart(session):
+    Common.create_non_admin_user_by_api('smb_test_user', 'SMB Test User', 'testing', 'True')
     Common.login_to_truenas(private_config['USERNAME'], private_config['PASSWORD'])
+
+
+def pytest_sessionfinish(session, exitstatus):
+    Common.delete_user_by_api('smb_test_user')

--- a/test_cases/webui/shares/smb/test_create_new_smb_share.py
+++ b/test_cases/webui/shares/smb/test_create_new_smb_share.py
@@ -15,7 +15,6 @@ def test_create_new_smb_share(user_data, smb_data) -> None:
     DATASET.delete_dataset_by_api(smb_data['path'])
     DATASET.create_dataset_by_api(smb_data['path'], 'SMB')
 
-    COM.login_to_truenas(user_data['username'], user_data['password'])
     NAV.navigate_to_shares()
     assert COMSHARE.assert_share_card_displays('smb')
 

--- a/test_cases/webui/shares/smb/test_create_new_smb_share_with_acl.py
+++ b/test_cases/webui/shares/smb/test_create_new_smb_share_with_acl.py
@@ -17,7 +17,6 @@ def test_create_new_smb_share_with_acl(user_data, smb_data) -> None:
     # note creating 'generic' dataset will cause smb share creation to prompt for acl configuration
     DATASET.create_dataset_by_api(smb_data['path'])
 
-    COM.login_to_truenas(user_data['username'], user_data['password'])
     NAV.navigate_to_shares()
     assert COMSHARE.assert_share_card_displays('smb')
 

--- a/test_cases/webui/shares/smb/test_create_new_smb_share_with_advanced_options.py
+++ b/test_cases/webui/shares/smb/test_create_new_smb_share_with_advanced_options.py
@@ -16,7 +16,6 @@ def test_create_new_smb_share_with_advanced_options(user_data, smb_data) -> None
     # note creating 'generic' dataset will cause smb share creation to prompt for acl configuration
     DATASET.create_dataset_by_api(smb_data['path'])
 
-    COM.login_to_truenas(user_data['username'], user_data['password'])
     NAV.navigate_to_shares()
     assert COMSHARE.assert_share_card_displays('smb')
 

--- a/test_cases/webui/shares/smb/test_create_new_smb_share_without_acl.py
+++ b/test_cases/webui/shares/smb/test_create_new_smb_share_without_acl.py
@@ -16,7 +16,6 @@ def test_create_new_smb_share_without_acl(user_data, smb_data) -> None:
     # note creating 'generic' dataset will cause smb share creation to prompt for acl configuration
     DATASET.create_dataset_by_api(smb_data['path'])
 
-    COM.login_to_truenas(user_data['username'], user_data['password'])
     NAV.navigate_to_shares()
     assert COMSHARE.assert_share_card_displays('smb')
 

--- a/test_cases/webui/shares/smb/test_delete_new_smb_share.py
+++ b/test_cases/webui/shares/smb/test_delete_new_smb_share.py
@@ -15,7 +15,6 @@ def test_delete_new_smb_share(user_data, smb_data) -> None:
     DATASET.create_dataset_by_api(smb_data['path'], 'SMB')
     COMSHARE.create_share_by_api('smb', smb_data['name'], smb_data['path'])
 
-    COM.login_to_truenas(user_data['username'], user_data['password'])
     NAV.navigate_to_shares()
     assert COMSHARE.assert_share_card_displays('smb')
     COMSHARE.assert_share_name('smb', smb_data['name'])

--- a/test_cases/webui/shares/smb/test_edit_smb_share.py
+++ b/test_cases/webui/shares/smb/test_edit_smb_share.py
@@ -17,7 +17,6 @@ def test_edit_smb_share(user_data, smb_data) -> None:
     DATASET.create_dataset_by_api(smb_data['path_alt'], 'SMB')
     COMSHARE.create_share_by_api('smb', smb_data['name'], smb_data['path'])
 
-    COM.login_to_truenas(user_data['username'], user_data['password'])
     NAV.navigate_to_shares()
     assert COMSHARE.assert_share_card_displays('smb')
 

--- a/test_cases/webui/shares/smb/test_edit_smb_share_acl.py
+++ b/test_cases/webui/shares/smb/test_edit_smb_share_acl.py
@@ -18,7 +18,6 @@ def test_edit_smb_share_acl(user_data, smb_data) -> None:
     DATASET.create_dataset_by_api(smb_data['path'])
     COMSHARE.create_share_by_api('smb', smb_data['name'], smb_data['path'])
 
-    COM.login_to_truenas(user_data['username'], user_data['password'])
     NAV.navigate_to_shares()
     assert COMSHARE.assert_share_card_displays('smb')
 


### PR DESCRIPTION
Removed login in all smb test and created conftest.py.
Added improvement for some smb keywords.
Added code to create a user for all smb test in conftest.py.
Removed WebUI.wait_until_not_visible('(//ix-icon[@name="cancel"])[1]') in click save button.
Changed visible to clickable in cancel_confirm_dialog.
Fixed is_service_running.