### PR TITLE
TEN-1028/24.04.0/pipeline fix Read Only Admin Local Groups

### DIFF
--- a/keywords/webui/local_groups.py
+++ b/keywords/webui/local_groups.py
@@ -20,6 +20,32 @@ class Local_Groups:
         assert COM.is_visible(xpaths.common_xpaths.any_pill("sudo-commands-nopasswd", command))
 
     @classmethod
+    def assert_add_local_group_button_is_locked_and_not_clickable(cls) -> bool:
+        """
+        This method verifies if the add local group button is locked and not clickable.
+
+        :return: True if the add local group button is locked and not clickable, otherwise it returns False.
+
+        Example:
+            - Local_Groups.assert_add_local_group_button_is_locked_and_not_clickable()
+        """
+        return COM.assert_button_is_locked_and_not_clickable('add')
+
+    @classmethod
+    def assert_delete_local_group_button_is_locked_and_not_clickable(cls, name: str) -> bool:
+        """
+        This method verifies if the add local group button is locked and not clickable.
+
+        :param name: is the name of the group to be deleted
+        :return: True if the add local group button is locked and not clickable, otherwise it returns False.
+
+        Example:
+            - Local_Groups.assert_delete_local_group_button_is_locked_and_not_clickable()
+        """
+        name = COM.convert_to_tag_format(name)
+        return COM.assert_button_is_locked_and_not_clickable(f'{name}-delete')
+
+    @classmethod
     def assert_gid_field_is_disabled(cls) -> bool:
         """
         This method returns True if the gid text field is disabled, otherwise False
@@ -349,7 +375,8 @@ class Local_Groups:
          - Local_Groups.expand_group_by_name('group_name')
         """
         group_name = COM.convert_to_tag_format(group_name)
-        COM.click_on_element(f'//*[@data-test="row-{group_name}"]')
+        if COM.is_visible(xpaths.common_xpaths.button_field(f"{group_name}-edit")) is False:
+            COM.click_on_element(f'//*[@data-test="row-{group_name}"]')
 
     @classmethod
     def get_group_list_allow_sudo_commands(cls, group) -> str:
@@ -634,3 +661,4 @@ class Local_Groups:
          - Local_Groups.unset_show_builtin_groups_toggle()
         """
         COM.unset_toggle('show-built-in-groups')
+

--- a/test_cases/webui/restricted_admin/read-only-admin/test_read_only_admin_local_groups.py
+++ b/test_cases/webui/restricted_admin/read-only-admin/test_read_only_admin_local_groups.py
@@ -2,8 +2,6 @@ import allure
 import pytest
 
 import xpaths.common_xpaths
-from keywords.api.post import API_POST
-from keywords.api.delete import API_DELETE
 from keywords.webui.common import Common as COM
 from keywords.webui.local_groups import Local_Groups as LG
 from keywords.webui.navigation import Navigation as NAV
@@ -27,7 +25,14 @@ class Test_Read_Only_Admin_Local_Groups:
     @allure.story("Read Only Admin Can See The Local Groups")
     def test_read_only_admin_can_see_the_local_groups(self):
         """
-        This test verifies the read-only admin is able to see Local Groups.
+        Summary: This test verifies the read-only admin is able to see Local Groups.
+
+        Test Steps:
+        1. Verify the read-only admin is able to see Local Groups
+        2. Expand Local Groups
+        3. Verify Local Groups members button
+        4. Verify Local Groups edit button
+        5. Verify Local Groups delete button
         """
         assert COM.is_visible(xpaths.common_xpaths.any_data_test("row-roa")) is True
         LG.expand_group_by_name("roa")
@@ -39,7 +44,14 @@ class Test_Read_Only_Admin_Local_Groups:
     @allure.story("Read Only Admin Can View the Local Groups Members")
     def test_read_only_admin_can_view_the_local_groups_members(self):
         """
-        This test verifies the read-only admin is able to view the local groups members.
+        Summary: This test verifies the read-only admin is able to view the local groups members.
+
+        Test Steps:
+        1. Expand Local Groups
+        2. Click Local Groups members button
+        3. Verify Update Members page
+        4. Verify save button
+        5. Navigate to Local Groups page
         """
         LG.expand_group_by_name("roa")
         LG.click_group_members_button("roa")
@@ -51,7 +63,14 @@ class Test_Read_Only_Admin_Local_Groups:
     @allure.story("Read Only Admin Can View the configured Local Group")
     def test_read_only_admin_can_view_the_configured_local_group(self):
         """
-        This test verifies the read-only admin is able to view the configured local group.
+        Summary: This test verifies the read-only admin is able to view the configured local group.
+
+        Test Steps:
+        1. Expand Local Groups
+        2. Click Local Groups edit button
+        3. Verify Edit Group right panel
+        4. Verify Local Group fields (gid, name, privileges, etc)
+        5. Close right panel
         """
         LG.expand_group_by_name("roa")
         LG.click_group_edit_button_by_name("roa")
@@ -71,7 +90,10 @@ class Test_Read_Only_Admin_Local_Groups:
     @allure.story("Read Only Admin Is Not Able to add a Local Groups")
     def test_read_only_admin_can_not_add_local_group(self):
         """
-        This test verifies the read-only admin is not able to add a Local Groups.
+        Summary: This test verifies the read-only admin is not able to add a Local Groups.
+
+        Test Steps:
+        1. Verify the add Local Groups button is locked and not clickable
         """
         assert LG.assert_add_local_group_button_is_locked_and_not_clickable() is True
 
@@ -79,7 +101,11 @@ class Test_Read_Only_Admin_Local_Groups:
     @allure.story("Read Only Admin Is Not Able to delete a Local Groups")
     def test_read_only_admin_can_not_delete_local_group(self):
         """
-        This test verifies the read-only admin is not able to delete a Local Groups.
+        Summary: This test verifies the read-only admin is not able to delete a Local Groups.
+
+        Test Steps:
+        1. Expand Local Groups
+        2. Verify the delete Local Groups button is locked and not clickable
         """
         LG.expand_group_by_name("roa")
         assert LG.assert_delete_local_group_button_is_locked_and_not_clickable('roa') is True
@@ -88,7 +114,13 @@ class Test_Read_Only_Admin_Local_Groups:
     @allure.story("Read Only Admin Is Not Able to modify a Local Groups")
     def test_read_only_admin_can_not_modify_local_group(self):
         """
-        This test verifies the read-only admin is not able to modify a Local Groups.
+        Summary: This test verifies the read-only admin is not able to modify a Local Groups.
+
+        Test Steps:
+        1. Expand Local Groups
+        2. Click Local Groups edit button
+        3. Verify the save Local Groups button is locked and not clickable
+        4. Close right panel
         """
         LG.expand_group_by_name("roa")
         LG.click_group_edit_button_by_name("roa")

--- a/test_cases/webui/restricted_admin/read-only-admin/test_read_only_admin_local_groups.py
+++ b/test_cases/webui/restricted_admin/read-only-admin/test_read_only_admin_local_groups.py
@@ -23,13 +23,6 @@ class Test_Read_Only_Admin_Local_Groups:
         """
         NAV.navigate_to_local_groups()
 
-    @pytest.fixture(autouse=True, scope='class')
-    def tear_down_test(self):
-        """
-        This teardown fixture delete the Local Groups and read-only admin for all test cases.
-        """
-        yield
-
     @allure.tag("Read")
     @allure.story("Read Only Admin Can See The Local Groups")
     def test_read_only_admin_can_see_the_local_groups(self):

--- a/test_cases/webui/restricted_admin/read-only-admin/test_read_only_admin_local_groups.py
+++ b/test_cases/webui/restricted_admin/read-only-admin/test_read_only_admin_local_groups.py
@@ -1,0 +1,103 @@
+import allure
+import pytest
+
+import xpaths.common_xpaths
+from keywords.api.post import API_POST
+from keywords.api.delete import API_DELETE
+from keywords.webui.common import Common as COM
+from keywords.webui.local_groups import Local_Groups as LG
+from keywords.webui.navigation import Navigation as NAV
+
+
+@allure.tag('Read Only Admin', 'Local Groups', "Users", 'Permissions', 'Data Protection')
+@allure.epic('Permissions')
+@allure.feature('Read Only Admin')
+class Test_Read_Only_Admin_Local_Groups:
+    """
+    This test class tests read-only admin Local Groups
+    """
+    @pytest.fixture(autouse=True, scope='class')
+    def setup_test(self):
+        """
+        This setup fixture create the dataset and read-only admin for all test cases.
+        """
+        NAV.navigate_to_local_groups()
+
+    @pytest.fixture(autouse=True, scope='class')
+    def tear_down_test(self):
+        """
+        This teardown fixture delete the Local Groups and read-only admin for all test cases.
+        """
+        yield
+
+    @allure.tag("Read")
+    @allure.story("Read Only Admin Can See The Local Groups")
+    def test_read_only_admin_can_see_the_local_groups(self):
+        """
+        This test verifies the read-only admin is able to see Local Groups.
+        """
+        assert COM.is_visible(xpaths.common_xpaths.any_data_test("row-roa")) is True
+        LG.expand_group_by_name("roa")
+        assert COM.is_visible(xpaths.common_xpaths.button_field("roa-members")) is True
+        assert COM.is_visible(xpaths.common_xpaths.button_field("roa-edit")) is True
+        assert COM.is_visible(xpaths.common_xpaths.button_field("roa-delete")) is True
+
+    @allure.tag("Read")
+    @allure.story("Read Only Admin Can View the Local Groups Members")
+    def test_read_only_admin_can_view_the_local_groups_members(self):
+        """
+        This test verifies the read-only admin is able to view the local groups members.
+        """
+        LG.expand_group_by_name("roa")
+        LG.click_group_members_button("roa")
+        assert COM.assert_page_header("Update Members") is True
+        assert COM.is_visible(xpaths.common_xpaths.button_field("save")) is True
+        NAV.navigate_to_local_groups()
+
+    @allure.tag("Read")
+    @allure.story("Read Only Admin Can View the configured Local Group")
+    def test_read_only_admin_can_view_the_configured_local_group(self):
+        """
+        This test verifies the read-only admin is able to view the configured local group.
+        """
+        LG.expand_group_by_name("roa")
+        LG.click_group_edit_button_by_name("roa")
+        assert COM.assert_right_panel_header("Edit Group") is True
+        assert COM.is_visible(xpaths.common_xpaths.input_field("gid")) is True
+        assert COM.is_visible(xpaths.common_xpaths.input_field("name")) is True
+        assert COM.is_visible(xpaths.common_xpaths.input_field("privileges")) is True
+        assert COM.is_visible(xpaths.common_xpaths.input_field("sudo-commands")) is True
+        assert COM.is_visible(xpaths.common_xpaths.checkbox_field("sudo-commands-all")) is True
+        assert COM.is_visible(xpaths.common_xpaths.input_field("sudo-commands-nopasswd")) is True
+        assert COM.is_visible(xpaths.common_xpaths.checkbox_field("sudo-commands-nopasswd-all")) is True
+        assert COM.is_visible(xpaths.common_xpaths.checkbox_field("smb")) is True
+        assert COM.is_visible(xpaths.common_xpaths.button_field("save")) is True
+        COM.close_right_panel()
+
+    @allure.tag("Read")
+    @allure.story("Read Only Admin Is Not Able to add a Local Groups")
+    def test_read_only_admin_can_not_add_local_group(self):
+        """
+        This test verifies the read-only admin is not able to add a Local Groups.
+        """
+        assert LG.assert_add_local_group_button_is_locked_and_not_clickable() is True
+
+    @allure.tag("Read")
+    @allure.story("Read Only Admin Is Not Able to delete a Local Groups")
+    def test_read_only_admin_can_not_delete_local_group(self):
+        """
+        This test verifies the read-only admin is not able to delete a Local Groups.
+        """
+        LG.expand_group_by_name("roa")
+        assert LG.assert_delete_local_group_button_is_locked_and_not_clickable('roa') is True
+
+    @allure.tag("Read")
+    @allure.story("Read Only Admin Is Not Able to modify a Local Groups")
+    def test_read_only_admin_can_not_modify_local_group(self):
+        """
+        This test verifies the read-only admin is not able to modify a Local Groups.
+        """
+        LG.expand_group_by_name("roa")
+        LG.click_group_edit_button_by_name("roa")
+        assert COM.assert_button_is_locked_and_not_clickable('save') is True
+        COM.close_right_panel()

--- a/test_cases/webui/restricted_admin/read-only-admin/test_read_only_admin_periodic_snapshot_tasks.py
+++ b/test_cases/webui/restricted_admin/read-only-admin/test_read_only_admin_periodic_snapshot_tasks.py
@@ -42,7 +42,10 @@ class Test_Read_Only_Admin_Periodic_Snapshot_Tasks:
     @allure.story("Read Only Admin Can See The Periodic Snapshot Tasks")
     def test_read_only_admin_can_see_the_periodic_snapshot_tasks(self):
         """
-        This test verifies the read-only admin is able to see Periodic Snapshot tasks.
+        Summary: This test verifies the read-only admin is able to see Periodic Snapshot tasks.
+
+        Test Steps:
+        1. Verify the read-only admin is able to see Periodic Snapshot tasks
         """
         assert DP.assert_periodic_snapshot_task_dataset('tank/persnap_ro') is True
 
@@ -50,7 +53,14 @@ class Test_Read_Only_Admin_Periodic_Snapshot_Tasks:
     @allure.story("Read Only Admin Can View the Configured Periodic Snapshot Task")
     def test_read_only_admin_can_view_the_configured_periodic_snapshot_task(self):
         """
-        This test verifies the read-only admin is able to view the configured Periodic Snapshot task.
+        Summary: This test verifies the read-only admin is able to view the configured Periodic Snapshot task.
+
+        Test Steps:
+        1. Click Edit Periodic Snapshot task
+        2. Verify Periodic Snapshot Task fields (dataset, exclude, recursive, etc)
+        3. Verify sub-sections (dataset, Schedule)
+        4. Verify can view Custom Schedule dialog
+        5. Close right panel
         """
         DP.click_edit_periodic_snapshot_task('tank/persnap_ro')
         assert COM.is_visible(xpaths.common_xpaths.select_field("dataset")) is True
@@ -77,7 +87,10 @@ class Test_Read_Only_Admin_Periodic_Snapshot_Tasks:
     @allure.story("Read Only Admin Is Not Able to add a Periodic Snapshot task")
     def test_read_only_admin_can_not_add_periodic_snapshot_task(self):
         """
-        This test verifies the read-only admin is not able to add a Periodic Snapshot task.
+        Summary: This test verifies the read-only admin is not able to add a Periodic Snapshot task.
+
+        Test Steps:
+        1. Verify the add periodic snapshot task button is locked and not clickable
         """
         assert DP.assert_add_periodic_snapshot_task_button_is_locked_and_not_clickable() is True
 
@@ -85,7 +98,10 @@ class Test_Read_Only_Admin_Periodic_Snapshot_Tasks:
     @allure.story("Read Only Admin Is Not Able to delete a Periodic Snapshot task")
     def test_read_only_admin_can_not_delete_periodic_snapshot_task(self):
         """
-        This test verifies the read-only admin is not able to delete a Periodic Snapshot task.
+        Summary: This test verifies the read-only admin is not able to delete a Periodic Snapshot task.
+
+        Test Steps:
+        1. Verify the delete periodic snapshot task button is locked and not clickable
         """
         assert DP.assert_delete_periodic_snapshot_task_button_is_locked_and_not_clickable('tank/persnap_ro') is True
 
@@ -93,7 +109,12 @@ class Test_Read_Only_Admin_Periodic_Snapshot_Tasks:
     @allure.story("Read Only Admin Is Not Able to modify a Periodic Snapshot task")
     def test_read_only_admin_can_not_modify_periodic_snapshot_task(self):
         """
-        This test verifies the read-only admin is not able to modify a Periodic Snapshot task.
+        Summary: This test verifies the read-only admin is not able to modify a Periodic Snapshot task.
+
+        Test Steps:
+        1. Click Edit Periodic Snapshot task
+        2. Verify the save periodic snapshot task button is locked and not clickable
+        3. Close right panel
         """
         DP.click_edit_periodic_snapshot_task('tank/persnap_ro')
         assert COM.assert_button_is_locked_and_not_clickable('save') is True
@@ -103,7 +124,13 @@ class Test_Read_Only_Admin_Periodic_Snapshot_Tasks:
     @allure.story("Read Only Admin Is Not Able to enable and disable Periodic Snapshot tasks")
     def test_read_only_admin_can_not_enable_and_disable_periodic_snapshot_task(self):
         """
-        This test verifies the read-only admin is not able to enable and disable Periodic Snapshot tasks.
+        Summary: This test verifies the read-only admin is not able to enable and disable Periodic Snapshot tasks.
+
+        Test Steps:
+        1. Verify the enabled periodic snapshot task toggle is locked and not clickable
+        2. Set periodic snapshot to disabled through API
+        3. Refresh page (re-navigate to Data Protection page)
+        4. Verify the disabled periodic snapshot task toggle is locked and not clickable
         """
         assert DP.assert_enable_periodic_snapshot_task_toggle_is_locked_and_not_clickable('tank/persnap_ro') is True
         API_PUT.set_periodic_snapshot_task_enabled('tank/persnap_ro', False)
@@ -114,7 +141,12 @@ class Test_Read_Only_Admin_Periodic_Snapshot_Tasks:
     @allure.story("Read Only Admin Can See The VM Periodic Snapshot Tasks")
     def test_read_only_admin_can_see_the_vm_periodic_snapshot_tasks(self):
         """
-        This test verifies the read-only admin is not able to run the Periodic Snapshot task.
+        Summary: This test verifies the read-only admin is not able to run the Periodic Snapshot task.
+
+        Test Steps:
+        1. Click VMware Periodic Snapshot task button
+        2. Verify the vmware periodic snapshot page displays
+        3. Navigate to Data Protection page
         """
         COM.click_link('snapshot-task-vmware-snapshots')
         assert COM.assert_page_header('VMware Snapshots') is True
@@ -124,7 +156,12 @@ class Test_Read_Only_Admin_Periodic_Snapshot_Tasks:
     @allure.story("Read Only Admin Is Not Able to add a VM Periodic Snapshot")
     def test_read_only_admin_can_not_add_vm_periodic_snapshot(self):
         """
-        This test verifies the read-only admin is not able to add a VM Periodic Snapshot.
+        Summary: This test verifies the read-only admin is not able to add a VM Periodic Snapshot.
+
+        Test Steps:
+        1. Click VMware Periodic Snapshot task button
+        2. Verify the add VMware periodic snapshot task button is locked and not clickable
+        3. Navigate to Data Protection page
         """
         COM.click_link('snapshot-task-vmware-snapshots')
         assert DP.assert_add_vm_periodic_snapshot_button_is_locked_and_not_clickable() is True
@@ -135,7 +172,12 @@ class Test_Read_Only_Admin_Periodic_Snapshot_Tasks:
     @pytest.mark.skip(reason="@@@ test_read_only_admin_can_not_delete_vm_periodic_snapshot: Currently ONLY available on a VMware box.")
     def test_read_only_admin_can_not_delete_vm_periodic_snapshot(self):
         """
-        This test verifies the read-only admin is not able to delete a Periodic Snapshot task.
+        Summary: This test verifies the read-only admin is not able to delete a Periodic Snapshot task.
+
+        Test Steps:
+        1. Click VMware Periodic Snapshot task button
+        2. Verify the delete VMware periodic snapshot task button is locked and not clickable
+        3. Navigate to Data Protection page
         """
         COM.click_link('snapshot-task-vmware-snapshots')
         assert DP.assert_delete_vm_periodic_snapshot_task_button_is_locked_and_not_clickable('tank/persnap_ro') is True
@@ -146,7 +188,13 @@ class Test_Read_Only_Admin_Periodic_Snapshot_Tasks:
     @pytest.mark.skip(reason="@@@ test_read_only_admin_can_not_modify_vm_periodic_snapshot: Currently ONLY available on a VMware box.")
     def test_read_only_admin_can_not_modify_vm_periodic_snapshot(self):
         """
-        This test verifies the read-only admin is not able to modify a Periodic Snapshot task.
+        Summary: This test verifies the read-only admin is not able to modify a Periodic Snapshot task.
+
+        Test Steps:
+        1. Click VMware Periodic Snapshot task button
+        2. Click Edit VMware Periodic Snapshot task
+        3. Verify the save VMware periodic snapshot task button is locked and not clickable
+        4. Navigate to Data Protection page
         """
         COM.click_link('snapshot-task-vmware-snapshots')
         DP.click_edit_vm_periodic_snapshot_task('tank/persnap_ro')

--- a/test_cases/webui/restricted_admin/share-admin/test_share_admin_periodic_snapshot_tasks.py
+++ b/test_cases/webui/restricted_admin/share-admin/test_share_admin_periodic_snapshot_tasks.py
@@ -42,7 +42,10 @@ class Test_Share_Admin_Periodic_Snapshot_Tasks:
     @allure.story("Share Admin Can See The Periodic Snapshot Tasks")
     def test_share_admin_can_see_the_periodic_snapshot_tasks(self):
         """
-        This test verifies the share admin is able to see Periodic Snapshot tasks.
+        Summary: This test verifies the share admin is able to see Periodic Snapshot tasks.
+
+        Test Steps:
+        1. Verify the share admin is able to see Periodic Snapshot tasks
         """
         assert DP.assert_periodic_snapshot_task_dataset('tank/persnap_ro') is True
 
@@ -50,7 +53,14 @@ class Test_Share_Admin_Periodic_Snapshot_Tasks:
     @allure.story("Share Admin Can View the Configured Periodic Snapshot Task")
     def test_share_admin_can_view_the_configured_periodic_snapshot_task(self):
         """
-        This test verifies the share admin is able to view the configured Periodic Snapshot task.
+        Summary: This test verifies the share admin is able to view the configured Periodic Snapshot task.
+
+        Test Steps:
+        1. Click Edit Periodic Snapshot task
+        2. Verify Periodic Snapshot Task fields (dataset, exclude, recursive, etc)
+        3. Verify sub-sections (dataset, Schedule)
+        4. Verify can view Custom Schedule dialog
+        5. Close right panel
         """
         DP.click_edit_periodic_snapshot_task('tank/persnap_ro')
         assert COM.is_visible(xpaths.common_xpaths.select_field("dataset")) is True
@@ -77,7 +87,10 @@ class Test_Share_Admin_Periodic_Snapshot_Tasks:
     @allure.story("Share Admin Is Not Able to add a Periodic Snapshot task")
     def test_share_admin_can_not_add_periodic_snapshot_task(self):
         """
-        This test verifies the share admin is not able to add a Periodic Snapshot task.
+        Summary: This test verifies the share admin is not able to add a Periodic Snapshot task.
+
+        Test Steps:
+        1. Verify the add periodic snapshot task button is locked and not clickable
         """
         assert DP.assert_add_periodic_snapshot_task_button_is_locked_and_not_clickable() is True
 
@@ -85,7 +98,10 @@ class Test_Share_Admin_Periodic_Snapshot_Tasks:
     @allure.story("Share Admin Is Not Able to delete a Periodic Snapshot task")
     def test_share_admin_can_not_delete_periodic_snapshot_task(self):
         """
-        This test verifies the share admin is not able to delete a Periodic Snapshot task.
+        Summary: This test verifies the share admin is not able to delete a Periodic Snapshot task.
+
+        Test Steps:
+        1. Verify the delete periodic snapshot task button is locked and not clickable
         """
         assert DP.assert_delete_periodic_snapshot_task_button_is_locked_and_not_clickable('tank/persnap_ro') is True
 
@@ -93,7 +109,12 @@ class Test_Share_Admin_Periodic_Snapshot_Tasks:
     @allure.story("Share Admin Is Not Able to modify a Periodic Snapshot task")
     def test_share_admin_can_not_modify_periodic_snapshot_task(self):
         """
-        This test verifies the share admin is not able to modify a Periodic Snapshot task.
+        Summary: This test verifies the share admin is not able to modify a Periodic Snapshot task.
+
+        Test Steps:
+        1. Click Edit Periodic Snapshot task
+        2. Verify the save periodic snapshot task button is locked and not clickable
+        3. Close right panel
         """
         DP.click_edit_periodic_snapshot_task('tank/persnap_ro')
         assert COM.assert_button_is_locked_and_not_clickable('save') is True
@@ -103,7 +124,13 @@ class Test_Share_Admin_Periodic_Snapshot_Tasks:
     @allure.story("Share Admin Is Not Able to enable and disable Periodic Snapshot tasks")
     def test_share_admin_can_not_enable_and_disable_periodic_snapshot_task(self):
         """
-        This test verifies the share admin is not able to enable and disable Periodic Snapshot tasks.
+        Summary: This test verifies the share admin is not able to enable and disable Periodic Snapshot tasks.
+
+        Test Steps:
+        1. Verify the enabled periodic snapshot task toggle is locked and not clickable
+        2. Set periodic snapshot to disabled through API
+        3. Refresh page (re-navigate to Data Protection page)
+        4. Verify the disabled periodic snapshot task toggle is locked and not clickable
         """
         assert DP.assert_enable_periodic_snapshot_task_toggle_is_locked_and_not_clickable('tank/persnap_ro') is True
         API_PUT.set_periodic_snapshot_task_enabled('tank/persnap_ro', False)
@@ -114,7 +141,12 @@ class Test_Share_Admin_Periodic_Snapshot_Tasks:
     @allure.story("Share Admin Can See The VM Periodic Snapshot Tasks")
     def test_share_admin_can_see_the_vm_periodic_snapshot_tasks(self):
         """
-        This test verifies the share admin is not able to run the Periodic Snapshot task.
+        Summary: This test verifies the share admin is not able to run the Periodic Snapshot task.
+
+        Test Steps:
+        1. Click VMware Periodic Snapshot task button
+        2. Verify the vmware periodic snapshot page displays
+        3. Navigate to Data Protection page
         """
         COM.click_link('snapshot-task-vmware-snapshots')
         assert COM.assert_page_header('VMware Snapshots') is True
@@ -124,7 +156,12 @@ class Test_Share_Admin_Periodic_Snapshot_Tasks:
     @allure.story("Share Admin Is Not Able to add a VM Periodic Snapshot")
     def test_share_admin_can_not_add_vm_periodic_snapshot(self):
         """
-        This test verifies the share admin is not able to add a VM Periodic Snapshot.
+        Summary: This test verifies the share admin is not able to add a VM Periodic Snapshot.
+
+        Test Steps:
+        1. Click VMware Periodic Snapshot task button
+        2. Verify the add VMware periodic snapshot task button is locked and not clickable
+        3. Navigate to Data Protection page
         """
         COM.click_link('snapshot-task-vmware-snapshots')
         assert DP.assert_add_vm_periodic_snapshot_button_is_locked_and_not_clickable() is True
@@ -135,7 +172,12 @@ class Test_Share_Admin_Periodic_Snapshot_Tasks:
     @pytest.mark.skip(reason="@@@ test_share_admin_can_not_delete_vm_periodic_snapshot: Currently ONLY available on a VMware box.")
     def test_share_admin_can_not_delete_vm_periodic_snapshot(self):
         """
-        This test verifies the share admin is not able to delete a Periodic Snapshot task.
+        Summary: This test verifies the share admin is not able to delete a Periodic Snapshot task.
+
+        Test Steps:
+        1. Click VMware Periodic Snapshot task button
+        2. Verify the delete VMware periodic snapshot task button is locked and not clickable
+        3. Navigate to Data Protection page
         """
         COM.click_link('snapshot-task-vmware-snapshots')
         assert DP.assert_delete_vm_periodic_snapshot_task_button_is_locked_and_not_clickable('tank/persnap_ro') is True
@@ -146,7 +188,13 @@ class Test_Share_Admin_Periodic_Snapshot_Tasks:
     @pytest.mark.skip(reason="@@@ test_share_admin_can_not_modify_vm_periodic_snapshot: Currently ONLY available on a VMware box.")
     def test_share_admin_can_not_modify_vm_periodic_snapshot(self):
         """
-        This test verifies the share admin is not able to modify a Periodic Snapshot task.
+        Summary: This test verifies the share admin is not able to modify a Periodic Snapshot task.
+
+        Test Steps:
+        1. Click VMware Periodic Snapshot task button
+        2. Click Edit VMware Periodic Snapshot task
+        3. Verify the save VMware periodic snapshot task button is locked and not clickable
+        4. Navigate to Data Protection page
         """
         COM.click_link('snapshot-task-vmware-snapshots')
         DP.click_edit_vm_periodic_snapshot_task('tank/persnap_ro')


### PR DESCRIPTION
added read-only admin Local Groups tests
![image](https://github.com/truenas/ScaleAutomation/assets/121878364/a630ecdd-97e0-4a4c-8910-da89b870ea5d)
