### PR TITLE
TEN-1359/24.10.0/pipeline add Read-Only Admin Share Admin Cloud Sync tests

### DIFF
--- a/keywords/api/put.py
+++ b/keywords/api/put.py
@@ -363,7 +363,7 @@ class API_PUT:
             - API_PUT.set_cloud_sync_task_enabled('name', False)
         """
         cred_id = 0
-        response = GET(f'/cloudsync/credentials?name={name}').json()
+        response = GET(f'/cloudsync?description={name}').json()
         if response:
             cred_id = response[0]['id']
         payload = {

--- a/test_cases/webui/restricted_admin/read-only-admin/test_read_only_admin_cloud_sync_tasks.py
+++ b/test_cases/webui/restricted_admin/read-only-admin/test_read_only_admin_cloud_sync_tasks.py
@@ -135,7 +135,7 @@ class Test_Read_Only_Admin_Cloud_Sync_Tasks:
         4. Verify the disabled Cloud Sync task toggle is locked and not clickable
         """
         assert DP.assert_enable_cloud_sync_task_toggle_is_restricted(cloud_sync['description']) is True
-        API_PUT.set_cloud_sync_task_enabled(cloud_sync['name'], False)
+        API_PUT.set_cloud_sync_task_enabled(cloud_sync['description'], False)
         NAV.navigate_to_data_protection()
         assert DP.assert_enable_cloud_sync_task_toggle_is_restricted(cloud_sync['description']) is True
 

--- a/test_cases/webui/restricted_admin/share-admin/test_share_admin_cloud_sync_tasks.py
+++ b/test_cases/webui/restricted_admin/share-admin/test_share_admin_cloud_sync_tasks.py
@@ -135,7 +135,7 @@ class Test_Share_Admin_Cloud_Sync_Tasks:
         4. Verify the disabled Cloud Sync task toggle is locked and not clickable
         """
         assert DP.assert_enable_cloud_sync_task_toggle_is_restricted(cloud_sync['description']) is True
-        API_PUT.set_cloud_sync_task_enabled(cloud_sync['name'], False)
+        API_PUT.set_cloud_sync_task_enabled(cloud_sync['description'], False)
         NAV.navigate_to_data_protection()
         assert DP.assert_enable_cloud_sync_task_toggle_is_restricted(cloud_sync['description']) is True
 


### PR DESCRIPTION
fixed read-only admin Cloud Sync tests
fixed share admin Cloud Sync tests
![image](https://github.com/truenas/ScaleAutomation/assets/121878364/b94cdb7e-23ad-482c-b92b-1e74d8f5b0a1)
![image](https://github.com/truenas/ScaleAutomation/assets/121878364/fbf86d1b-5ab2-493f-a59d-f9bf7e477414)
