### PR TITLE
TEN-1040/24.04.2/pipeline add Read-Only Admin Alert Settings tests

### DIFF
--- a/keywords/webui/alert_settings.py
+++ b/keywords/webui/alert_settings.py
@@ -1,0 +1,18 @@
+from helper.webui import WebUI
+from keywords.webui.common import Common as COM
+
+
+class Alert_Settings:
+
+    @classmethod
+    def assert_alert_category_save_button_restricted(cls, category: str) -> None:
+        """
+        This method returns True if the update page header is visible otherwise it returns False.
+
+        :param category: name of the category.
+        :return: True if the update page header is visible otherwise it returns False.
+        """
+        COM.click_button("categories")
+        WebUI.delay(0.1)
+        COM.click_button(f'category-{category}')
+        assert COM.assert_button_is_restricted('save') is True

--- a/keywords/webui/common.py
+++ b/keywords/webui/common.py
@@ -1011,7 +1011,7 @@ class Common:
         return file.is_file()
 
     @classmethod
-    def is_input_visible(cls, name) -> bool:
+    def is_input_visible(cls, name: str) -> bool:
         """
         This method returns True if the given input is visible, otherwise False.
 
@@ -1024,7 +1024,7 @@ class Common:
         return cls.is_visible(xpaths.common_xpaths.input_field(cls.convert_to_tag_format(name)))
 
     @classmethod
-    def is_link_visible(cls, name) -> bool:
+    def is_link_visible(cls, name: str) -> bool:
         """
         This method returns True if the given link is visible, otherwise False.
 
@@ -1049,7 +1049,7 @@ class Common:
         return cls.get_element_property(xpaths.common_xpaths.button_field('save'), 'disabled')
 
     @classmethod
-    def is_select_visible(cls, name) -> bool:
+    def is_select_visible(cls, name: str) -> bool:
         """
         This method returns True if the given select is visible, otherwise False.
 
@@ -1062,7 +1062,22 @@ class Common:
         return cls.is_visible(xpaths.common_xpaths.select_field(cls.convert_to_tag_format(name)))
 
     @classmethod
-    def is_text_visible(cls, text) -> bool:
+    def is_select_by_row_visible(cls, name: str, row: int = 1) -> bool:
+        """
+        This method returns True if the given select is visible, otherwise False.
+
+        :param name: name of the select.
+        :param row: index of the select. default = 1
+        :return: True if the given select is visible, otherwise False.
+
+        Example:
+            - Common.is_select_by_row_visible('search')
+            - Common.is_select_by_row_visible('search', 2)
+        """
+        return cls.is_visible(xpaths.common_xpaths.select_field_by_row(cls.convert_to_tag_format(name), row))
+
+    @classmethod
+    def is_text_visible(cls, text: str) -> bool:
         """
         This method returns True if the given text is visible, otherwise False.
 
@@ -1075,7 +1090,7 @@ class Common:
         return cls.is_visible(xpaths.common_xpaths.any_text(text))
 
     @classmethod
-    def is_textarea_visible(cls, name) -> bool:
+    def is_textarea_visible(cls, name: str) -> bool:
         """
         This method returns True if the given textarea is visible, otherwise False.
 
@@ -1101,7 +1116,7 @@ class Common:
         return eval(cls.get_element_property(xpaths.common_xpaths.toggle_field(name), 'ariaChecked').capitalize())
 
     @classmethod
-    def is_toggle_visible(cls, name) -> bool:
+    def is_toggle_visible(cls, name: str) -> bool:
         """
         This method returns True if the given toggle is visible, otherwise False.
 

--- a/keywords/webui/navigation.py
+++ b/keywords/webui/navigation.py
@@ -183,9 +183,19 @@ class Navigation:
         This method navigates to the Advanced page under the System Settings panel.
 
         Example
-         - Navigation.navigate_to_system_settings_services()
+         - Navigation.navigate_to_system_settings_advanced()
         """
         cls.navigate_to('system-settings', 'Advanced', 'advanced')
+
+    @classmethod
+    def navigate_to_system_settings_alert_settings(cls) -> None:
+        """
+        This method navigates to the Alert Settings page under the System Settings panel.
+
+        Example
+         - Navigation.navigate_to_system_settings_alert_settings()
+        """
+        cls.navigate_to('system-settings', 'Alert Settings', 'alert-settings')
 
     @classmethod
     def navigate_to_system_settings_boot(cls) -> None:

--- a/test_cases/webui/restricted_admin/read-only-admin/test_read_only_admin_system_settings_alert_settings.py
+++ b/test_cases/webui/restricted_admin/read-only-admin/test_read_only_admin_system_settings_alert_settings.py
@@ -2,6 +2,7 @@ import allure
 import pytest
 
 from helper.webui import WebUI
+from keywords.webui.alert_settings import Alert_Settings as ALERT
 from keywords.webui.common import Common as COM
 from keywords.webui.navigation import Navigation as NAV
 
@@ -127,74 +128,15 @@ class Test_Read_Only_Admin_System_Settings_Alert_Settings:
         1. Click category button (Applications, Certificates, Directory Services)
         2. Verify the Save Debug button is locked and not clickable
         """
-        # Application Category
-        COM.click_button("categories")
-        WebUI.delay(0.1)
-        COM.click_button('category-applications')
-        assert COM.assert_button_is_restricted('save') is True
-
-        # Certificates Category
-        COM.click_button("categories")
-        WebUI.delay(0.1)
-        COM.click_button('category-certificates')
-        assert COM.assert_button_is_restricted('save') is True
-
-        # Directory Services Category
-        COM.click_button("categories")
-        WebUI.delay(0.1)
-        COM.click_button('category-directory-service')
-        assert COM.assert_button_is_restricted('save') is True
-
-        # Hardware Category
-        COM.click_button("categories")
-        WebUI.delay(0.1)
-        COM.click_button('category-hardware')
-        assert COM.assert_button_is_restricted('save') is True
-
-        # Key Management Interoperability Protocol (KMIP) Category
-        COM.click_button("categories")
-        WebUI.delay(0.1)
-        COM.click_button('category-kmip')
-        assert COM.assert_button_is_restricted('save') is True
-
-        # Network Category
-        COM.click_button("categories")
-        WebUI.delay(0.1)
-        COM.click_button('category-network')
-        assert COM.assert_button_is_restricted('save') is True
-
-        # Reporting Category
-        COM.click_button("categories")
-        WebUI.delay(0.1)
-        COM.click_button('category-reporting')
-        assert COM.assert_button_is_restricted('save') is True
-
-        # Sharing Category
-        COM.click_button("categories")
-        WebUI.delay(0.1)
-        COM.click_button('category-sharing')
-        assert COM.assert_button_is_restricted('save') is True
-
-        # Storage Category
-        COM.click_button("categories")
-        WebUI.delay(0.1)
-        COM.click_button('category-storage')
-        assert COM.assert_button_is_restricted('save') is True
-
-        # System Category
-        COM.click_button("categories")
-        WebUI.delay(0.1)
-        COM.click_button('category-system')
-        assert COM.assert_button_is_restricted('save') is True
-
-        # Tasks Category
-        COM.click_button("categories")
-        WebUI.delay(0.1)
-        COM.click_button('category-tasks')
-        assert COM.assert_button_is_restricted('save') is True
-
-        # UPS Category
-        COM.click_button("categories")
-        WebUI.delay(0.1)
-        COM.click_button('category-ups')
-        assert COM.assert_button_is_restricted('save') is True
+        ALERT.assert_alert_category_save_button_restricted('applications')
+        ALERT.assert_alert_category_save_button_restricted('certificates')
+        ALERT.assert_alert_category_save_button_restricted('directory-service')
+        ALERT.assert_alert_category_save_button_restricted('hardware')
+        ALERT.assert_alert_category_save_button_restricted('kmip')
+        ALERT.assert_alert_category_save_button_restricted('network')
+        ALERT.assert_alert_category_save_button_restricted('reporting')
+        ALERT.assert_alert_category_save_button_restricted('sharing')
+        ALERT.assert_alert_category_save_button_restricted('storage')
+        ALERT.assert_alert_category_save_button_restricted('system')
+        ALERT.assert_alert_category_save_button_restricted('tasks')
+        ALERT.assert_alert_category_save_button_restricted('ups')

--- a/test_cases/webui/restricted_admin/read-only-admin/test_read_only_admin_system_settings_alert_settings.py
+++ b/test_cases/webui/restricted_admin/read-only-admin/test_read_only_admin_system_settings_alert_settings.py
@@ -1,0 +1,202 @@
+import allure
+import pytest
+
+import xpaths
+from helper.webui import WebUI
+from keywords.webui.common import Common as COM
+from keywords.webui.navigation import Navigation as NAV
+
+
+@allure.tag('Read Only Admin', 'System Settings', 'Alert Settings Page', "Users", 'Permissions')
+@allure.epic('Permissions')
+@allure.feature('Read Only Admin')
+class Test_Read_Only_Admin_System_Settings_Alert_Settings:
+
+    @pytest.fixture(autouse=True, scope='class')
+    def setup_system_settings_alert_settings(self):
+        """
+        Summary: This setup fixture System Settings Alert Settings page for all test cases.
+        """
+        NAV.navigate_to_system_settings_alert_settings()
+
+    @allure.tag("Read")
+    @allure.issue('NAS-129415', 'NAS-129415')
+    @allure.issue('NAS-129437', 'NAS-129437')
+    @allure.story("Read Only Admin Can See the System Settings Alert Settings Page")
+    def test_read_only_admin_can_see_the_system_settings_alert_settings(self):
+        """
+        Summary: This test verifies the read-only admin is able to access and see all details in the System Settings > Alert Settings view.
+
+        Test Steps:
+        1. Verify the read-only admin is able to see Alert Settings view page (title, Columns, Add)
+        2. Verify the read-only admin is able to see various Card details (Alert Settings, Category)
+        """
+        assert COM.assert_page_header('Alert Settings')
+
+        # Alert Services Card
+        assert COM.is_text_visible('Alert Services') is True
+        assert COM.is_input_visible('table-filter') is True
+        assert COM.is_button_visible('alert-services-columns-menu') is True
+        assert COM.is_button_visible('alert-services-add') is True
+        assert COM.is_button_visible('alert-services-options') is True
+
+        # Category Card
+        # TODO: NAS-129437 - convert to is_card_visible()
+        # assert COM.is_card_visible('Category') is True
+        assert COM.is_text_visible('Category') is True
+        assert COM.is_button_visible('categories') is True
+        # TODO: NAS-129415
+        # Application Update Available
+        assert COM.is_select_by_row_visible('level') is True
+        assert COM.is_select_by_row_visible('policy') is True
+        # Catalog Not Healthy
+        assert COM.is_select_by_row_visible('level', 2) is True
+        assert COM.is_select_by_row_visible('policy', 2) is True
+        # Unable to Configure Applications
+        assert COM.is_select_by_row_visible('level', 3) is True
+        assert COM.is_select_by_row_visible('policy', 3) is True
+        # Unable to Start Applications
+        assert COM.is_select_by_row_visible('level', 4) is True
+        assert COM.is_select_by_row_visible('policy', 4) is True
+        # Unable to Sync Catalog
+        assert COM.is_select_by_row_visible('level', 5) is True
+        assert COM.is_select_by_row_visible('policy', 5) is True
+
+        assert COM.is_button_visible('save') is True
+
+    @allure.tag("Create")
+    @allure.story("Read Only Admin Is Not Able to Add Any Alert Services")
+    def test_read_only_admin_not_able_to_add_any_alert_services(self):
+        """
+        Summary: This test verifies the read-only user is not able to add any alert services.
+
+        Test Steps:
+        1. Click Add Alert Service button
+        2. Verify the Save Debug button is locked and not clickable
+        3. Verify Send Test Alert button is locked and not clickable
+        """
+        COM.click_button("alert-services-add")
+        assert COM.assert_right_panel_header('Add Alert Service')
+        assert COM.assert_button_is_restricted('save') is True
+        assert COM.assert_button_is_restricted('send-test-alert') is True
+        COM.close_right_panel()
+
+    @allure.tag("Update")
+    @allure.story("Read Only Admin Is Not Able to Modify Any Alert Settings Settings")
+    def test_read_only_admin_not_able_to_modify_any_alert_settings_settings(self):
+        """
+        Summary: This test verifies the read-only user is not able to modify any alert settings settings.
+
+        Test Steps:
+        1. Click Alert Service options button (three dots)
+        2. Click edit option
+        3. Verify the Save Debug button is locked and not clickable
+        4. Verify Send Test Alert button is locked and not clickable
+        """
+        COM.click_button("alert-services-options")
+        COM.click_button('alert-services-options-edit')
+        assert COM.assert_right_panel_header('Edit Alert Service')
+        assert COM.assert_button_is_restricted('save') is True
+        assert COM.assert_button_is_restricted('send-test-alert') is True
+        COM.close_right_panel()
+
+    @allure.tag("Delete")
+    @allure.story("Read Only Admin Is Not Able to Delete Any Alert Services")
+    def test_read_only_admin_not_able_to_delete_any_alert_services(self):
+        """
+        Summary: This test verifies the read-only user is not able to delete any alert services.
+
+        Test Steps:
+        1. Click Alert Service options button (three dots)
+        2. Click delete option
+        3. Confirm the Deleter dialog
+        4. Verify Delete Error dialog appears
+        """
+        COM.click_button("alert-services-options")
+        COM.click_button('alert-services-options-delete')
+        COM.assert_confirm_dialog()
+        assert COM.assert_text_is_visible('Access denied to alertservice.delete') is True
+        COM.click_error_dialog_close_button()
+
+    @allure.tag("Update")
+    @allure.story("Read Only Admin Is Not Able to Modify Any Category Settings")
+    def test_read_only_admin_not_able_to_modify_any_category_settings(self):
+        """
+        Summary: This test verifies the read-only user is not able to modify any category settings.
+
+        Test Steps: (for each category)
+        1. Click category button (Applications, Certificates, Directory Services)
+        2. Verify the Save Debug button is locked and not clickable
+        """
+        # Application Category
+        COM.click_button("categories")
+        WebUI.delay(0.1)
+        COM.click_button('category-applications')
+        assert COM.assert_button_is_restricted('save') is True
+
+        # Certificates Category
+        COM.click_button("categories")
+        WebUI.delay(0.1)
+        COM.click_button('category-certificates')
+        assert COM.assert_button_is_restricted('save') is True
+
+        # Directory Services Category
+        COM.click_button("categories")
+        WebUI.delay(0.1)
+        COM.click_button('category-directory-service')
+        assert COM.assert_button_is_restricted('save') is True
+
+        # Hardware Category
+        COM.click_button("categories")
+        WebUI.delay(0.1)
+        COM.click_button('category-hardware')
+        assert COM.assert_button_is_restricted('save') is True
+
+        # Key Management Interoperability Protocol (KMIP) Category
+        COM.click_button("categories")
+        WebUI.delay(0.1)
+        COM.click_button('category-kmip')
+        assert COM.assert_button_is_restricted('save') is True
+
+        # Network Category
+        COM.click_button("categories")
+        WebUI.delay(0.1)
+        COM.click_button('category-network')
+        assert COM.assert_button_is_restricted('save') is True
+
+        # Reporting Category
+        COM.click_button("categories")
+        WebUI.delay(0.1)
+        COM.click_button('category-reporting')
+        assert COM.assert_button_is_restricted('save') is True
+
+        # Sharing Category
+        COM.click_button("categories")
+        WebUI.delay(0.1)
+        COM.click_button('category-sharing')
+        assert COM.assert_button_is_restricted('save') is True
+
+        # Storage Category
+        COM.click_button("categories")
+        WebUI.delay(0.1)
+        COM.click_button('category-storage')
+        assert COM.assert_button_is_restricted('save') is True
+
+        # System Category
+        COM.click_button("categories")
+        WebUI.delay(0.1)
+        COM.click_button('category-system')
+        assert COM.assert_button_is_restricted('save') is True
+
+        # Tasks Category
+        COM.click_button("categories")
+        WebUI.delay(0.1)
+        COM.click_button('category-tasks')
+        assert COM.assert_button_is_restricted('save') is True
+
+        # UPS Category
+        COM.click_button("categories")
+        WebUI.delay(0.1)
+        COM.click_button('category-ups')
+        assert COM.assert_button_is_restricted('save') is True
+

--- a/test_cases/webui/restricted_admin/read-only-admin/test_read_only_admin_system_settings_alert_settings.py
+++ b/test_cases/webui/restricted_admin/read-only-admin/test_read_only_admin_system_settings_alert_settings.py
@@ -1,7 +1,6 @@
 import allure
 import pytest
 
-from helper.webui import WebUI
 from keywords.webui.alert_settings import Alert_Settings as ALERT
 from keywords.webui.common import Common as COM
 from keywords.webui.navigation import Navigation as NAV

--- a/test_cases/webui/restricted_admin/read-only-admin/test_read_only_admin_system_settings_alert_settings.py
+++ b/test_cases/webui/restricted_admin/read-only-admin/test_read_only_admin_system_settings_alert_settings.py
@@ -1,7 +1,6 @@
 import allure
 import pytest
 
-import xpaths
 from helper.webui import WebUI
 from keywords.webui.common import Common as COM
 from keywords.webui.navigation import Navigation as NAV
@@ -199,4 +198,3 @@ class Test_Read_Only_Admin_System_Settings_Alert_Settings:
         WebUI.delay(0.1)
         COM.click_button('category-ups')
         assert COM.assert_button_is_restricted('save') is True
-


### PR DESCRIPTION
added read-only admin Alert Settings tests
![image](https://github.com/truenas/ScaleAutomation/assets/121878364/00c60d03-1329-4aa1-abac-c4621b77347a)
