### PR TITLE
TEN-1419/24.04.2/pipeline fix Read-Only Admin Iscsi Share tests

### DIFF
--- a/keywords/webui/common_shares.py
+++ b/keywords/webui/common_shares.py
@@ -161,7 +161,7 @@ class Common_Shares:
            - Common_Shares.assert_disable_share_service_is_restricted('smb')
         """
         COM.click_on_element(xpaths.common_xpaths.button_share_actions_menu(share_type))
-        share_type = 'cifs' if share_type == 'smb' else share_type
+        share_type = SS.return_backend_service_name(share_type, False)
         result = COM.assert_button_is_restricted(f'{share_type}-actions-menu-turn-off-service')
         WebUI.send_key('esc')
         return result
@@ -178,7 +178,7 @@ class Common_Shares:
            - Common_Shares.assert_enable_share_service_is_restricted('smb')
         """
         COM.click_on_element(xpaths.common_xpaths.button_share_actions_menu(share_type))
-        share_type = 'cifs' if share_type == 'smb' else share_type
+        share_type = SS.return_backend_service_name(share_type, False)
         result = COM.assert_button_is_restricted(f'{share_type}-actions-menu-turn-on-service')
         WebUI.send_key('esc')
         return result


### PR DESCRIPTION
fixed restricted pipeline failures
Failed tests are due to existing defect and unrelated change (cloud sync description changed from "Amazon S3" to "S3"

![image](https://github.com/truenas/ScaleAutomation/assets/121878364/6fdcb13f-5e65-4e44-9f12-8ffdf4d9b731)
